### PR TITLE
use registry-image with docker hub mirror

### DIFF
--- a/security-considerations/security-considerations.yml
+++ b/security-considerations/security-considerations.yml
@@ -1,9 +1,11 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: 18fgsa/concourse-task
+    repository_mirror:
+      host: docker-registry-mirror.app.cloud.gov:443
 
 inputs:
   - name: pull-request


### PR DESCRIPTION
## Changes proposed in this pull request:

Change to registry-image type and user our docker registry mirror

## security considerations

None
