### PR TITLE
use the correct property

### DIFF
--- a/security-considerations/security-considerations.yml
+++ b/security-considerations/security-considerations.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: 18fgsa/concourse-task
-    repository_mirror:
+    registry_mirror:
       host: docker-registry-mirror.app.cloud.gov:443
 
 inputs:


### PR DESCRIPTION
## Changes proposed in this pull request:

registry_mirrror is the correct property. Sorry for the typo.

## security considerations

None
