### PR TITLE
add docker-registry-mirror to the list of site for security checks

### DIFF
--- a/security-considerations/repos.txt
+++ b/security-considerations/repos.txt
@@ -39,6 +39,7 @@ cloud-gov/cg-deploy-stratos
 cloud-gov/cg-deploy-volume-services
 cloud-gov/cg-diagrams
 cloud-gov/cg-django-uaa
+cloud-gov/docker-registry-mirror
 cloud-gov/cg-elb-log-ingestor
 cloud-gov/cg-elb-log-ingestor-boshrelease
 cloud-gov/cg-harden-boshrelease


### PR DESCRIPTION
## Changes proposed in this pull request:

As the cloud-gov/docker-registry-mirror repo to the list of repos w/ security checks

## security considerations

This ensures security checks are run on the new repo.
