### PR TITLE
Add cg-uaa-extras-redis-migrator repo

### DIFF
--- a/security-considerations/repos.txt
+++ b/security-considerations/repos.txt
@@ -84,4 +84,4 @@ cloud-gov/s3-resource-simple
 cloud-gov/shibboleth-boshrelease
 cloud-gov/uaa-customized-boshrelease
 cloud-gov/uaa-bot
-cloud-gov/cg-uaa-extras-redis-migrator/
+cloud-gov/cg-uaa-extras-redis-migrator

--- a/security-considerations/repos.txt
+++ b/security-considerations/repos.txt
@@ -84,3 +84,4 @@ cloud-gov/s3-resource-simple
 cloud-gov/shibboleth-boshrelease
 cloud-gov/uaa-customized-boshrelease
 cloud-gov/uaa-bot
+cloud-gov/cg-uaa-extras-redis-migrator/


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds the https://github.com/cloud-gov/cg-uaa-extras-redis-migrator/ repo to this check

## Security considerations:
- Ensures that a new repo is being checked for security considerations within its PRs to maintain compliance