### PR TITLE
use chdir instead of positional dir argument

### DIFF
--- a/terraform-destroy.sh
+++ b/terraform-destroy.sh
@@ -17,20 +17,17 @@ if [ "${PREVENT_PREVENT_DESTROY:-}" == "true" ]; then
   find terraform-templates -type f -name "*.tf" -exec sed -i 's/prevent_destroy = true/prevent_destroy = false/g' {} +
 fi
 
-${TERRAFORM} get \
-  -update \
-  "${DIR}"
+${TERRAFORM} -chdir=${DIR} get \
+  -update 
 
-${TERRAFORM} init \
+${TERRAFORM} -chdir=${DIR} init \
   -backend=true \
   -backend-config="encrypt=true" \
   -backend-config="bucket=${S3_TFSTATE_BUCKET}" \
-  -backend-config="key=${STACK_NAME}/terraform.tfstate" \
-  "${DIR}"
+  -backend-config="key=${STACK_NAME}/terraform.tfstate" 
 
-terraform destroy \
+terraform -chdir=${DIR} destroy \
   -refresh=true \
-  -force \
-  "${DIR}"
+  -force
 
 aws s3 cp "s3://${S3_TFSTATE_BUCKET}/${STACK_NAME}/terraform.tfstate" terraform-state


### PR DESCRIPTION
terraform 0.14 supports this, and terraform >= 0.15 requires this. the behavior is notably different - with chdir, tf actually changes directories to the one specified; this means other relative paths have to be updated to reflect that

## Changes proposed in this pull request:
- use chdir instead of positional dir argument


## security considerations
None