### PR TITLE
Avoid printing credentials to logs

### DIFF
--- a/terraform-apply.sh
+++ b/terraform-apply.sh
@@ -36,6 +36,7 @@ init_args=(
   "-backend-config=bucket=${S3_TFSTATE_BUCKET}"
   "-backend-config=key=${STACK_NAME}/terraform.tfstate"
 )
+set +x
 if [ -n "${TF_VAR_aws_region:-}" ]; then
   init_args+=("-backend-config=region=${TF_VAR_aws_region}")
 fi
@@ -48,6 +49,7 @@ fi
 
 ${TERRAFORM} -chdir="${DIR}" init \
   "${init_args[@]}" 
+set -x
 
 if [ "${TERRAFORM_ACTION}" = "plan" ]; then
   ${TERRAFORM} -chdir="${DIR}" "${TERRAFORM_ACTION}" \


### PR DESCRIPTION
## Changes proposed in this pull request:

- Set `+x` around commands handling credentials

## security considerations

This patches a security issue.