### PR TITLE
use general-task

### DIFF
--- a/uaa-smoke-tests.yml
+++ b/uaa-smoke-tests.yml
@@ -2,10 +2,13 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: python
-    tag: "3.6-alpine"
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest
 
 inputs:
 - name: pipeline-tasks


### PR DESCRIPTION
## Changes proposed in this pull request:
- Replace python image with our general-task image

## security considerations
Uses a hardened image instead of the generally available python image