### PR TITLE
Make it easier to grok Terraform output in Concourse

### DIFF
--- a/terraform-apply.sh
+++ b/terraform-apply.sh
@@ -27,8 +27,7 @@ if [ -n "${TEMPLATE_SUBDIR:-}" ]; then
   DIR="${DIR}/${TEMPLATE_SUBDIR}"
 fi
 
-${TERRAFORM} -chdir=${DIR} get \
-  -update > terraform-get-output.txt
+${TERRAFORM} -chdir=${DIR} get -update > terraform-get-output.txt
 
 init_args=(
   "-backend=true"

--- a/terraform-apply.sh
+++ b/terraform-apply.sh
@@ -28,7 +28,7 @@ if [ -n "${TEMPLATE_SUBDIR:-}" ]; then
 fi
 
 ${TERRAFORM} -chdir=${DIR} get \
-  -update 
+  -update > terraform-get-output.txt
 
 init_args=(
   "-backend=true"
@@ -58,7 +58,8 @@ if [ "${TERRAFORM_ACTION}" = "plan" ]; then
     -out=${BASE}/terraform-state/terraform.tfplan \
     > ${BASE}/terraform-state/terraform-plan-output.txt
   
-  cat ${BASE}/terraform-state/terraform-plan-output.txt
+  cat ${BASE}/terraform-state/terraform-plan-output.txt | \
+    grep --line-buffered --extended-regexp "Reading\.\.\.|Read complete after|Refreshing state\.\.\."
 
   # Write a sentinel value; pipelines can alert to slack if set using `text_file`
   # Ensure that slack notification resource detects text file


### PR DESCRIPTION
## Changes proposed in this pull request:

* Send `terraform get` output to a log file instead of stdout since it does not need reviewed
* Filter `terraform plan` output for lines related to state updates. Full plan output, including state updates, still exists on disk in case it needs to be reviewed
* Leave `terraform apply` output untouched for now; just test out the changes in `plan`, which is what we read more anyway

## security considerations

None; reducing existing output to stdout.