### PR TITLE
removing the need for common in this script

### DIFF
--- a/bosh-logs-errand.sh
+++ b/bosh-logs-errand.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# vim: set ft=sh
+
+set -eu
+
+args=("${BOSH_ERRAND}")
+args+=(${BOSH_FLAGS:-})
+bosh -n run-errand "${args[@]}"

--- a/bosh-logs-errand.yml
+++ b/bosh-logs-errand.yml
@@ -1,0 +1,28 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest
+
+inputs:
+  - name: pipeline-tasks
+outputs:
+  - name: bosh-errand
+
+run:
+  path: pipeline-tasks/bosh-errand.sh
+
+params:
+  BOSH_ENVIRONMENT:
+  BOSH_CLIENT:
+  BOSH_CLIENT_SECRET:
+  BOSH_DEPLOYMENT:
+  BOSH_ERRAND:
+  BOSH_CA_CERT:
+  BOSH_FLAGS:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Common is a s3 bucket which we will not be needing in the future. This is a copy of a bosh errand script with the common input removed
-
-

## security considerations
Less reliance on S3 and more usage of credhub
