### PR TITLE
Make terraform apply output more concise, like plan output

### DIFF
--- a/terraform-apply.sh
+++ b/terraform-apply.sh
@@ -70,11 +70,13 @@ else
   ${TERRAFORM} -chdir="${DIR}" "${TERRAFORM_ACTION}" \
     -refresh=true \
     -input=false \
-    -auto-approve
+    -auto-approve \
+    | grep -v --line-buffered --extended-regexp "Reading\.\.\.|Read complete after|Refreshing state\.\.\."
   ${TERRAFORM} -chdir="${DIR}" "${TERRAFORM_ACTION}" \
     -refresh=true \
     -input=false \
-    -auto-approve
+    -auto-approve \
+    | grep -v --line-buffered --extended-regexp "Reading\.\.\.|Read complete after|Refreshing state\.\.\."
 
   if [ -n "${TF_VAR_aws_region:-}" ]; then
     export AWS_DEFAULT_REGION="${TF_VAR_aws_region}"


### PR DESCRIPTION
## Changes proposed in this pull request:

- Like with `terraform plan`, hide non-error lines related to state updates
- Tested in `terraform plan` over the last few months. We observed no loss of useful information.
- Discussed and approved here: https://gsa-tts.slack.com/archives/GS7RNLM1N/p1710941940840279

## security considerations

None.